### PR TITLE
Misc XML bug-fixes

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,4 @@
+{
+    "python-envs.defaultEnvManager": "renan-r-santos.pixi-code:pixi",
+    "python-envs.defaultPackageManager": "renan-r-santos.pixi-code:pixi"
+}

--- a/fewspy/__init__.py
+++ b/fewspy/__init__.py
@@ -6,5 +6,14 @@ from fewspy.io.read_parquet import read_parquet
 from fewspy.io.write_netcdf import write_netcdf
 from fewspy.time_series import TimeSeries, TimeSeriesSet
 
-__all__ = ["Api", "read_xml", "read_json", "read_netcdf", "read_parquet", "write_netcdf", "TimeSeries", "TimeSeriesSet"]
-__version__ = "2025.11.0"
+__all__ = [
+    "Api",
+    "read_xml",
+    "read_json",
+    "read_netcdf",
+    "read_parquet",
+    "write_netcdf",
+    "TimeSeries",
+    "TimeSeriesSet",
+]
+__version__ = "2026.3.0"

--- a/fewspy/io/read_xml.py
+++ b/fewspy/io/read_xml.py
@@ -1,15 +1,11 @@
-# %%
 from lxml import etree
 from pathlib import Path
-from fewspy.utils.conversions import snake_to_camel_case
 from fewspy.time_series import TimeSeriesSet
-from io import BytesIO
 
 ns = {"pi": "http://www.wldelft.nl/fews/PI"}
 
 
 def _parse_xml_data(root) -> TimeSeriesSet:
-    # root = xml_data.getroot()  # Root element
 
     version = root.attrib.get("version")
     time_zone_element = root.find("pi:timeZone", namespaces=ns)

--- a/fewspy/io/read_xml.py
+++ b/fewspy/io/read_xml.py
@@ -8,8 +8,8 @@ from io import BytesIO
 ns = {"pi": "http://www.wldelft.nl/fews/PI"}
 
 
-def _parse_xml_data(xml_data) -> TimeSeriesSet:
-    root = xml_data.getroot()  # Root element
+def _parse_xml_data(root) -> TimeSeriesSet:
+    # root = xml_data.getroot()  # Root element
 
     version = root.attrib.get("version")
     time_zone_element = root.find("pi:timeZone", namespaces=ns)
@@ -25,7 +25,7 @@ def _parse_xml_data(xml_data) -> TimeSeriesSet:
     # Loop over children (individual timeseries in the xml)
     for child in rootchildren:
         subchildren = child.getchildren()  # alle headers en en timevalues
-        metadata = None
+        metadata = {"qualifierId": None}
         data = []
 
         for subchild in subchildren:
@@ -34,11 +34,18 @@ def _parse_xml_data(xml_data) -> TimeSeriesSet:
                 "header"
             ):  # gewoonlijk eerste subchild is de header
                 header_childs = subchild.getchildren()
-                metadata = {}
+                metadata = {"qualifierId": None}
+
                 for item in header_childs:
                     key = item.tag.split("}")[-1]
-
                     item_keys = item.keys()
+
+                    # qualifierId kan meerdere keren voorkomen
+                    if key == "qualifierId":
+                        if metadata["qualifierId"] is None:
+                            metadata["qualifierId"] = []
+                        metadata["qualifierId"].append(item.text)
+                        continue
 
                     if len(item_keys) == 0:
                         metadata[key] = item.text
@@ -71,8 +78,8 @@ def read_xml(xml_path: Path) -> TimeSeriesSet:
         TimeSeriesSet: timeseries
     """
 
-    xml_data = etree.parse(xml_path)  # Parse XML data
-    return _parse_xml_data(xml_data)
+    root = etree.parse(xml_path).getroot()  # Parse XML data
+    return _parse_xml_data(root)
 
 
 def read_xml_from_string(xml_string: str) -> TimeSeriesSet:
@@ -85,5 +92,5 @@ def read_xml_from_string(xml_string: str) -> TimeSeriesSet:
         TimeSeriesSet: timeseries
     """
 
-    xml_data = etree.fromstring(xml_string.encode("utf-8"))
-    return _parse_xml_data(xml_data)
+    root = etree.fromstring(xml_string.encode("utf-8"))
+    return _parse_xml_data(root)

--- a/fewspy/time_series.py
+++ b/fewspy/time_series.py
@@ -44,14 +44,17 @@ def reliables(df: pd.DataFrame, threshold: int = 6) -> pd.DataFrame:
 class Header:
     """FEWS-PI header-style dataclass"""
 
+    # required arguments
     type: Literal["accumulative", "instantaneous"]
-    module_instance_id: str | None
     location_id: str
     parameter_id: str
     time_step: TimeStepDict
     start_date: datetime
     end_date: datetime
-    miss_val: float
+
+    # Optional arguments
+    module_instance_id: str | None
+    miss_val: float = float("nan")
     lat: float | None = None
     lon: float | None = None
     x: float | None = None

--- a/pixi.toml
+++ b/pixi.toml
@@ -1,4 +1,4 @@
-[project]
+[workspace]
 name = "fewspy"
 version = "0.6.3"
 description = "A Python API for the Deltares FEWS PI REST Web Service"

--- a/tests/get_timeseries_xml_test.py
+++ b/tests/get_timeseries_xml_test.py
@@ -1,0 +1,51 @@
+# %%
+from datetime import datetime
+from config import api
+
+import logging
+
+logging.basicConfig(level=logging.DEBUG)
+
+kwargs = dict(
+    filter_id="WDB_OW_KGM",
+    location_ids=["NL34.HL.KGM156.HWZ1", "NL34.HL.KGM156.LWZ1"],
+    start_time=datetime(2022, 5, 1),
+    end_time=datetime(2022, 5, 5),
+    parameter_ids=["Q [m3/s] [NVT] [OW]", "WATHTE [m] [NAP] [OW]"],
+    document_format="PI_XML",
+)
+
+timeseriesset = api.get_time_series(**kwargs)
+
+
+def test_time_zone():
+    assert timeseriesset.time_zone == 1.0
+
+
+def test_version():
+    assert timeseriesset.version == "1.31"
+
+
+def test_empty():
+    assert not timeseriesset.empty
+
+
+def test_length():
+    assert len(timeseriesset) == 2
+
+
+def test_parameter_ids():
+    assert timeseriesset.parameter_ids == ["WATHTE [m] [NAP] [OW]"]
+
+
+def test_location_ids():
+    assert all(
+        [
+            i in ["NL34.HL.KGM156.LWZ1", "NL34.HL.KGM156.HWZ1"]
+            for i in timeseriesset.location_ids
+        ]
+    )
+
+
+def test_qualifier_ids():
+    assert timeseriesset.qualifier_ids == ["productie"]

--- a/tests/twinpy_to_netcdf_test.py
+++ b/tests/twinpy_to_netcdf_test.py
@@ -6,15 +6,37 @@ from pathlib import Path
 
 DATA_PATH = Path(__file__).parent / "data"
 twinpy_tss = DATA_PATH.joinpath("io", "twin_fewspy_ts.pickle")
+tmpdir = DATA_PATH.joinpath("twinpy_to_netcdf")
 
-with open(twinpy_tss, "rb") as src:
-    time_series_set: TimeSeriesSet = pickle.load(src)
 
-out_dir = DATA_PATH.joinpath("io", "twinpy_to_netcdf")
-global_attributes = {
-    "institution": "HHNK",
-    "source": "TWINpy",
-    "title": "TWINpy export",
-}
+def test_twinpy(tmpdir):
 
-time_series_set.to_netcdf(out_dir=out_dir, global_attributes=global_attributes)
+    # open pickle
+    with open(twinpy_tss, "rb") as src:
+        time_series_set: TimeSeriesSet = pickle.load(src)
+
+    # to_netcdf settings
+    out_dir = Path(tmpdir).joinpath("twinpy_to_netcdf")
+    global_attributes = {
+        "institution": "HHNK",
+        "source": "TWINpy",
+        "title": "TWINpy export",
+    }
+
+    time_series_set.to_netcdf(out_dir=out_dir, global_attributes=global_attributes)
+
+    # check if netcdf files exist
+    assert out_dir.joinpath("CL.berekend.nc").exists()
+    assert out_dir.joinpath("EGVms_m.meting.nc").exists()
+    assert out_dir.joinpath("H.meting.nc").exists()
+    assert out_dir.joinpath("HTPB.meting.nc").exists()
+    assert out_dir.joinpath("Hz.meting.nc").exists()
+    assert out_dir.joinpath("Inlaat.stand.meting.nc").exists()
+    assert out_dir.joinpath("LTPB.meting.nc").exists()
+    assert out_dir.joinpath("O2.geh.meting.nc").exists()
+    assert out_dir.joinpath("P.meting.1m.nc").exists()
+    assert out_dir.joinpath("PB.meting.nc").exists()
+    assert out_dir.joinpath("Q.berekend.nc").exists()
+    assert out_dir.joinpath("Q.meting.nc").exists()
+    assert out_dir.joinpath("Stuw.stand.meting.nc").exists()
+    assert out_dir.joinpath("T.water.meting.nc").exists()


### PR DESCRIPTION
Aanpassingen/Fixes:
- fixed bug _parse_xml_data() -> gaat nu zowel bij bestand als string (bij API bevragingen) een root in (i.p.v. elementtree) en is nu ook getest. Closes #12 
-  fixed bug qualifierId -> repetatief element dat als een lijst moet worden opgenomen in de dict
- twinpy_to_netcdf_test.py -> was geen officiele test, nu wel
- ook voor twinpy -> de header-elementen zijn nu verplicht/niet verplicht conform https://fewsdocs.deltares.nl/schemas/version1.0/pi-schemas/pi_timeseries.xsd