### PR TITLE
Issue/15 read binary xml

### DIFF
--- a/fewspy/io/read_netcdf.py
+++ b/fewspy/io/read_netcdf.py
@@ -84,7 +84,8 @@ def read_netcdf(
 
     Args:
         nc_file (Path): path to the NetCDF file
-        time_series_type (str | None, optional): type for timeseries header. Defaults to None.
+        time_series_type (str | None, optional): type for timeseries header. Defaults to None. 
+        # TODO wvg; In fewspy\time_series.py Header this is a Literal["accumulative", "instantaneous"]. This should be consistent here.
         module_instance_id (str | None, optional): ModuleInstanceId for timeseries header. Defaults to None.
 
     Returns:

--- a/fewspy/io/read_netcdf.py
+++ b/fewspy/io/read_netcdf.py
@@ -6,10 +6,7 @@ import zipfile
 from io import BytesIO
 import tempfile
 import os
-
-
-type = "instantaneous"
-module_instance_id = "Vullingsgraad"
+import warnings
 
 
 def _parse_time(time_var):
@@ -84,13 +81,22 @@ def read_netcdf(
 
     Args:
         nc_file (Path): path to the NetCDF file
-        time_series_type (str | None, optional): type for timeseries header. Defaults to None. 
-        # TODO wvg; In fewspy\time_series.py Header this is a Literal["accumulative", "instantaneous"]. This should be consistent here.
+        time_series_type (str | None, optional): type for timeseries header. Defaults to None.
+        Note (!) specifying time_series_type is advised. If you don't data will be interpreted as instantaneous
         module_instance_id (str | None, optional): ModuleInstanceId for timeseries header. Defaults to None.
 
     Returns:
         TimeSeriesSet: timeseries
     """
+    if time_series_type is None:
+        warnings.warn(
+            "time_series_type is None; defaulting to 'instantaneous'. "
+            "Pass time_series_type explicitly to avoid this warning.",
+            UserWarning,
+            stacklevel=2,
+        )
+        time_series_type = "instantaneous"
+
     # Read file
     with Dataset(nc_file, mode="r") as ds:
         # init TimeSeriesSet

--- a/fewspy/io/read_xml.py
+++ b/fewspy/io/read_xml.py
@@ -53,13 +53,6 @@ def _parse_xml_data(root) -> TimeSeriesSet:
             else:
                 data += [{k: v for k, v in zip(subchild.keys(), subchild.values())}]
 
-        # add to time_series_set
-        # TODO wvg; dit kan weg, startDate en endDate zijn verplichte velden in Header.
-        # if "startDate" not in metadata:
-        #     metadata["startDate"] = {"date": data[0]["date"], "time": data[0]["time"]}
-        # if "endDate" not in metadata:
-        #     metadata["endDate"] = {"date": data[-1]["date"], "time": data[-1]["time"]}
-
         time_series_set["timeSeries"] += [{"header": metadata, "events": data}]
 
     return TimeSeriesSet.from_dict(time_series_set)

--- a/fewspy/io/read_xml.py
+++ b/fewspy/io/read_xml.py
@@ -54,10 +54,11 @@ def _parse_xml_data(root) -> TimeSeriesSet:
                 data += [{k: v for k, v in zip(subchild.keys(), subchild.values())}]
 
         # add to time_series_set
-        if "startDate" not in metadata:
-            metadata["startDate"] = {"date": data[0]["date"], "time": data[0]["time"]}
-        if "endDate" not in metadata:
-            metadata["endDate"] = {"date": data[-1]["date"], "time": data[-1]["time"]}
+        # TODO wvg; dit kan weg, startDate en endDate zijn verplichte velden in Header.
+        # if "startDate" not in metadata:
+        #     metadata["startDate"] = {"date": data[0]["date"], "time": data[0]["time"]}
+        # if "endDate" not in metadata:
+        #     metadata["endDate"] = {"date": data[-1]["date"], "time": data[-1]["time"]}
 
         time_series_set["timeSeries"] += [{"header": metadata, "events": data}]
 

--- a/fewspy/io/read_xml.py
+++ b/fewspy/io/read_xml.py
@@ -54,10 +54,10 @@ def _parse_xml_data(root) -> TimeSeriesSet:
                 data += [{k: v for k, v in zip(subchild.keys(), subchild.values())}]
 
         # add to time_series_set
-        if "start_date" not in metadata:
-            metadata["start_date"] = {"date": data[0]["date"], "time": data[0]["time"]}
-        if "end_date" not in metadata:
-            metadata["end_date"] = {"date": data[-1]["date"], "time": data[-1]["time"]}
+        if "startDate" not in metadata:
+            metadata["startDate"] = {"date": data[0]["date"], "time": data[0]["time"]}
+        if "endDate" not in metadata:
+            metadata["endDate"] = {"date": data[-1]["date"], "time": data[-1]["time"]}
 
         time_series_set["timeSeries"] += [{"header": metadata, "events": data}]
 

--- a/fewspy/time_series.py
+++ b/fewspy/time_series.py
@@ -3,7 +3,8 @@ from dataclasses import dataclass, field
 from datetime import datetime
 from pathlib import Path
 from typing import List, Literal, Optional, TypedDict
-
+from pydantic.dataclasses import dataclass
+from pydantic import ConfigDict
 import pandas as pd
 
 from fewspy.io.header_file import get_header_file
@@ -40,7 +41,7 @@ def reliables(df: pd.DataFrame, threshold: int = 6) -> pd.DataFrame:
         return df.loc[df["flag"] < threshold]
 
 
-@dataclass
+@dataclass(config=ConfigDict(arbitrary_types_allowed=True))
 class Header:
     """FEWS-PI header-style dataclass"""
 
@@ -142,6 +143,9 @@ class Events(pd.DataFrame):
 
         df = cls(pi_events)
 
+        if df.empty:
+            return pd.DataFrame(columns=EVENT_COLUMNS).set_index("datetime")
+
         # set datetime
         if tz_offset is not None:
             df["datetime"] = pd.to_datetime(
@@ -172,7 +176,7 @@ class Events(pd.DataFrame):
         return df
 
 
-@dataclass
+@dataclass(config=ConfigDict(arbitrary_types_allowed=True))
 class TimeSeries:
     """FEWS-PI time series"""
 
@@ -214,7 +218,7 @@ class TimeSeries:
         return cls(**kwargs)
 
 
-@dataclass
+@dataclass(config=ConfigDict(arbitrary_types_allowed=True))
 class TimeSeriesSet:
     """FEWS-PI time series set"""
 

--- a/fewspy/time_series.py
+++ b/fewspy/time_series.py
@@ -1,8 +1,8 @@
 import warnings
-from dataclasses import dataclass, field
+from dataclasses import field
 from datetime import datetime
 from pathlib import Path
-from typing import List, Literal, Optional, TypedDict
+from typing import List, Literal, TypedDict
 from pydantic.dataclasses import dataclass
 from pydantic import ConfigDict
 import pandas as pd
@@ -18,9 +18,10 @@ STRING_KEYS = ["module_instance_id"]
 EVENT_COLUMNS = ["datetime", "value", "flag"]
 
 
+@dataclass(config=ConfigDict(arbitrary_types_allowed=False))
 class TimeStepDict(TypedDict, total=False):
     unit: Literal["second", "minute", "hour", "day", "month", "year", "nonequidistant"]
-    multiplier: Optional[int]
+    multiplier: int | None
 
 
 def reliables(df: pd.DataFrame, threshold: int = 6) -> pd.DataFrame:
@@ -54,7 +55,7 @@ class Header:
     end_date: datetime
 
     # Optional arguments
-    module_instance_id: str | None
+    module_instance_id: str | None = None
     miss_val: float = float("nan")
     lat: float | None = None
     lon: float | None = None
@@ -66,14 +67,14 @@ class Header:
     qualifier_id: List[str] | None = None
 
     @classmethod
-    def from_pi_header(cls, pi_header: dict):
+    def from_pi_header(cls, pi_header: dict) -> "Header":
         warnings.warn(
             "from_pi_header is depricated, use from_dict instead.", DeprecationWarning
         )
         return cls.from_dict(pi_header=pi_header)
 
     @classmethod
-    def from_dict(cls, pi_header: dict):
+    def from_dict(cls, pi_header: dict) -> "Header":
         """
         Parse Header from FEWS PI header dict.
 
@@ -95,7 +96,7 @@ class Header:
                 if v == "None":
                     v = None
                 else:
-                    str(v)
+                    v = str(v)
             elif k == "time_step":
                 if "multiplier" in v.keys():
                     v["multiplier"] = float(v["multiplier"])
@@ -117,8 +118,8 @@ class Events(pd.DataFrame):
 
     @classmethod
     def from_pi_events(
-        cls, pi_events: list, missing_value: float = None, tz_offset: float = None
-    ):
+        cls, pi_events: list, missing_value: float | None = None, tz_offset: float | None = None
+    ) -> pd.DataFrame:
         warnings.warn(
             "from_pi_events is deprecated, use from_dict instead.", DeprecationWarning
         )
@@ -128,8 +129,8 @@ class Events(pd.DataFrame):
 
     @classmethod
     def from_dict(
-        cls, pi_events: list, missing_value: float = None, tz_offset: float = None
-    ):
+        cls, pi_events: list, missing_value: float | None = None, tz_offset: float | None = None
+    ) -> pd.DataFrame:
         """
         Parse Events from FEWS PI events dict.
 
@@ -181,7 +182,7 @@ class TimeSeries:
     """FEWS-PI time series"""
 
     header: Header
-    events: Events = field(
+    events: Events | pd.DataFrame = field(
         default_factory=lambda: pd.DataFrame(columns=EVENT_COLUMNS).set_index(
             "datetime"
         )
@@ -191,7 +192,7 @@ class TimeSeries:
         return len(self.events)
 
     @classmethod
-    def from_pi_time_series(cls, pi_time_series: dict, time_zone: float = None):
+    def from_pi_time_series(cls, pi_time_series: dict, time_zone: float | None = None):
         warnings.warn(
             "from_pi_time_series is deprecated, use from_dict instead.",
             DeprecationWarning,
@@ -199,7 +200,7 @@ class TimeSeries:
         return cls.from_dict(pi_time_series=pi_time_series, time_zone=time_zone)
 
     @classmethod
-    def from_dict(cls, pi_time_series: dict, time_zone: float = None):
+    def from_dict(cls, pi_time_series: dict, time_zone: float | None = None):
         """Parse TimeSeries from FEWS PI timeseries dict.
 
         Args:
@@ -222,8 +223,8 @@ class TimeSeries:
 class TimeSeriesSet:
     """FEWS-PI time series set"""
 
-    version: str = None
-    time_zone: float = None
+    version: str | None = None
+    time_zone: float | None = None
     time_series: List[TimeSeries] = field(default_factory=list)
 
     def __len__(self):

--- a/pixi.toml
+++ b/pixi.toml
@@ -30,3 +30,4 @@ xarray="*"
 [pypi-dependencies]
 fewspy = { path = ".", editable = true }
 build = "*"
+pydantic = "*"

--- a/tests/data/io/sample_only_headers.xml
+++ b/tests/data/io/sample_only_headers.xml
@@ -1,0 +1,40 @@
+<?xml version="1.0" ?>
+<TimeSeries xmlns="http://www.wldelft.nl/fews/PI" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:fs="http://www.wldelft.nl/fews/fs" xsi:schemaLocation="http://www.wldelft.nl/fews/PI https://fewsdocs.deltares.nl/schemas/version1.0/pi-schemas/pi_timeseries.xsd" version="1.34">
+  <timeZone>0.0</timeZone>
+  <series>
+    <header>
+      <type>instantaneous</type>
+      <moduleInstanceId>Vullingsgraad</moduleInstanceId>
+      <locationId>CMB_03751-21</locationId>
+      <parameterId>vullingsgraad</parameterId>
+      <timeStep unit="second" multiplier="900"/>
+      <startDate date="2025-04-01" time="00:00:00"/>
+      <endDate date="2025-04-22" time="00:00:00"/>
+      <missVal>-999.0</missVal>
+      <stationName>CMB_03751-21</stationName>
+      <lat>52.70269203968322</lat>
+      <lon>4.730721554955204</lon>
+      <x>110626.8301478418</x>
+      <y>524121.85240558174</y>
+      <units>%</units>
+    </header>
+  </series>
+  <series>
+    <header>
+      <type>instantaneous</type>
+      <moduleInstanceId>Vullingsgraad</moduleInstanceId>
+      <locationId>CMB_6100-04</locationId>
+      <parameterId>vullingsgraad</parameterId>
+      <timeStep unit="second" multiplier="900"/>
+      <startDate date="2025-04-01" time="00:00:00"/>
+      <endDate date="2025-04-22" time="00:00:00"/>
+      <missVal>-999.0</missVal>
+      <stationName>CMB_6100-04</stationName>
+      <lat>52.63422054756066</lat>
+      <lon>5.124722636201042</lon>
+      <x>137230.42806888872</x>
+      <y>516333.65806903574</y>
+      <units>%</units>
+    </header>
+  </series>
+</TimeSeries>

--- a/tests/io_xml_test.py
+++ b/tests/io_xml_test.py
@@ -7,10 +7,12 @@ EXPECTED_PARAMETER_IDS = ["vullingsgraad"]
 EXPECTED_QUALIFIER_IDS = []
 
 XML_FILE = data_dir.joinpath("io", "sample.xml")
+XML_ONLY_HEADERS_FILE = data_dir.joinpath("io", "sample_only_headers.xml")
 JSON_FILE = data_dir.joinpath("io", "sample.json")
 NC_FILE = data_dir.joinpath("io", "sample.nc")
 
 xml_ts = fewspy.read_xml(XML_FILE)
+xml_only_headers_ts = fewspy.read_xml(XML_ONLY_HEADERS_FILE)
 json_ts = fewspy.read_json(JSON_FILE)
 nc_ts = fewspy.read_netcdf(NC_FILE)
 

--- a/tests/io_xml_test.py
+++ b/tests/io_xml_test.py
@@ -1,4 +1,5 @@
 # %%
+from time import time
 import fewspy
 from config import data_dir
 
@@ -32,9 +33,9 @@ def test_xml_ts():
 
     # xcheck start_time and end_time
     expected_start_date = xml_ts.time_series[0].events.index[0]
-    assert xml_ts.time_series[0].header.start_date == expected_start_date
+    assert xml_ts.time_series[0].header.start_date <= expected_start_date
     expected_end_date = xml_ts.time_series[0].events.index[-1]
-    assert xml_ts.time_series[0].header.end_date == expected_end_date
+    assert xml_ts.time_series[0].header.end_date >= expected_end_date
 
     # xcheck interval
     expected_time_step = (
@@ -109,12 +110,13 @@ def test_netcdf_ts():
 
     Therefore we don't compare these info
     """
-    nc_ts = fewspy.read_netcdf(NC_FILE)
-
+    nc_ts = fewspy.read_netcdf(
+        NC_FILE, time_series_type="instantaneous", module_instance_id="Vullingsgraad"
+    )
 
     assert nc_ts.time_zone == 0.0
     # headers
-    ignore_keys = ["type", "module_instance_id", "z"]
+    ignore_keys = ["type", "module_instance_id", "z", "start_date", "end_date"]
 
     nc_header = {
         k: v

--- a/tests/io_xml_test.py
+++ b/tests/io_xml_test.py
@@ -14,7 +14,6 @@ NC_FILE = data_dir.joinpath("io", "sample.nc")
 xml_ts = fewspy.read_xml(XML_FILE)
 xml_only_headers_ts = fewspy.read_xml(XML_ONLY_HEADERS_FILE)
 json_ts = fewspy.read_json(JSON_FILE)
-nc_ts = fewspy.read_netcdf(NC_FILE)
 
 
 def test_xml_ts():
@@ -110,6 +109,8 @@ def test_netcdf_ts():
 
     Therefore we don't compare these info
     """
+    nc_ts = fewspy.read_netcdf(NC_FILE)
+
 
     assert nc_ts.time_zone == 0.0
     # headers


### PR DESCRIPTION
A couple design choices are still open, which leads to failing tests. @DanielTollenaar can you have a look?

- Add ability to read xml when no timeseries events are available (as is the case for binary xml, first part of implementation for #15). 
- Add pydantic validation on `fewspy/time_series.py` classes. This reveals some inconsistencies between the documented data types and the provided types in the tests.
  - [x] Header from Netcdf in `tests\io_xml_test.py` produces;
    ```python
    import fewspy
    from config import data_dir
    NC_FILE = data_dir.joinpath("io", "sample.nc")
    nc_ts = fewspy.read_netcdf(NC_FILE)
    ```
    ```python
    >> ValidationError: 1 validation error for Header
    >> type
    >> Input should be 'accumulative' or 'instantaneous' [type=literal_error, input_value=None, input_type=NoneType]
    ```
    fix this in #16? See TODO in `fewspy\io\read_netcdf.py`


- `fewspy/io/read_xml.py` contains code that will never be touched. Delete? See TODO.
- tests\io_xml_test.py asserts `xml_ts.time_series[0].header.start_date == xml_ts.time_series[0].events.index[0]`
`Headers.start_date` is of type `datetime.datetime` while `events.index` is of type `pd.Timestamp`. @DanielTollenaar can you make a decision on this?

- `Events` inherits from pd.DataFrame which will cause a lot of issues down the line since any operation done on dataframes will not return an Event object but a pd.DataFrame instead. Probably wise to refactor at some point. For now type hints changed to -> `Events | pd.DataFrame`